### PR TITLE
Hostname path change

### DIFF
--- a/1.3.4-127a/main.sh
+++ b/1.3.4-127a/main.sh
@@ -7,6 +7,11 @@ sed -i -e 's/^exit 101$/exit 0/g' /usr/sbin/policy-rc.d
 #Using the get_hostname for hostname instead of the host field in syslog messages
 sed -i.bak "s/record\[\"Host\"\] = hostname/record\[\"Host\"\] = OMS::Common.get_hostname/" /opt/microsoft/omsagent/plugin/filter_syslog.rb
 
+#using /var/opt/microsoft/docker-cimprov/state instead of /var/opt/microsoft/omsagent/state since the latter gets deleted during onboarding
+mkdir -p /var/opt/microsoft/docker-cimprov/state
+curl --unix-socket /var/run/docker.sock "http:/info" | python -c "import sys, json; print json.load(sys.stdin)['Name']" > /var/opt/microsoft/docker-cimprov/state/containerhostname
+sed -i.bak "s/\/var\/opt\/microsoft\/omsagent\/state\/containerhostname/\/var\/opt\/microsoft\/docker\-cimprov\/state\/containerhostname/" /opt/microsoft/omsagent/plugin/oms_common.rb
+
 #service omid start
 /opt/omi/bin/service_control start
 


### PR DESCRIPTION
using /var/opt/microsoft/docker-cimprov/state instead of /var/opt/microsoft/omsagent/state since the latter gets deleted during onboarding
Tested. Hostname is picked up without needing to mount. Will modify the path in oms_common.rb as part of a separate code review. 