### PR TITLE
Mixed tab/whitespace in Kubernetes config

### DIFF
--- a/Kubernetes/omsagent-ds-secrets.yaml
+++ b/Kubernetes/omsagent-ds-secrets.yaml
@@ -29,7 +29,7 @@ spec:
         - mountPath: /etc/omsagent-secret
           name: omsagent-secret
           readOnly: true
-	- mountPath: /var/lib/docker/containers 
+        - mountPath: /var/lib/docker/containers 
           name: containerlog-path  
        livenessProbe:
         exec:


### PR DESCRIPTION
The Kubernetes `omsagent-ds-secrets.yaml` file contains mixed tabs / whitespace, which prevents `kubectl` from running it.

This PR replaces the tab with whitespaces to resolve this problem.