### PR TITLE
Unmount volume /var/log and stop rsyslogd upon installation

### DIFF
--- a/Kubernetes/omsagent.yaml
+++ b/Kubernetes/omsagent.yaml
@@ -130,8 +130,6 @@ spec:
        volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-sock
-        - mountPath: /var/log 
-          name: host-log
         - mountPath: /var/lib/docker/containers 
           name: containerlog-path
         - mountPath: /etc/omsagent-secret
@@ -160,9 +158,6 @@ spec:
     - name: container-hostname
       hostPath:
        path: /etc/hostname
-    - name: host-log
-      hostPath:
-       path: /var/log
     - name: containerlog-path
       hostPath:
        path: /var/lib/docker/containers
@@ -224,8 +219,6 @@ spec:
        volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-sock
-        - mountPath: /var/log 
-          name: host-log
         - mountPath: /var/lib/docker/containers 
           name: containerlog-path
         - mountPath: /etc/omsagent-secret
@@ -251,9 +244,6 @@ spec:
     - name: container-hostname
       hostPath:
        path: /etc/hostname
-    - name: host-log
-      hostPath:
-       path: /var/log
     - name: containerlog-path
       hostPath:
        path: /var/lib/docker/containers
@@ -262,6 +252,4 @@ spec:
        secretName: omsagent-secret
     - name: omsagent-rs-config
       configMap:
-        name: omsagent-rs-config    
-
-
+        name: omsagent-rs-config

--- a/ci_feature/Dockerfile
+++ b/ci_feature/Dockerfile
@@ -4,7 +4,7 @@ LABEL vendor=Microsoft\ Corp \
 com.microsoft.product="OMS Container Docker Provider" \
 com.microsoft.version="2.0.0-7"
 ENV tmpdir /opt
-RUN /usr/bin/apt-get update && /usr/bin/apt-get install -y libc-bin wget openssl curl sudo python-ctypes sysv-rc net-tools rsyslog cron vim dmidecode apt-transport-https && rm -rf /var/lib/apt/lists/*
+RUN /usr/bin/apt-get update && /usr/bin/apt-get install -y libc-bin wget openssl curl sudo python-ctypes sysv-rc net-tools rsyslog cron vim dmidecode apt-transport-https && rm -rf /var/lib/apt/lists/* && service rsyslog stop
 COPY setup.sh main.sh $tmpdir/
 WORKDIR ${tmpdir}
 RUN chmod 775 $tmpdir/*.sh; sync; $tmpdir/setup.sh

--- a/ci_feature/Dockerfile
+++ b/ci_feature/Dockerfile
@@ -4,7 +4,7 @@ LABEL vendor=Microsoft\ Corp \
 com.microsoft.product="OMS Container Docker Provider" \
 com.microsoft.version="2.0.0-7"
 ENV tmpdir /opt
-RUN /usr/bin/apt-get update && /usr/bin/apt-get install -y libc-bin wget openssl curl sudo python-ctypes sysv-rc net-tools rsyslog cron vim dmidecode apt-transport-https && rm -rf /var/lib/apt/lists/* && service rsyslog stop
+RUN /usr/bin/apt-get update && /usr/bin/apt-get install -y libc-bin wget openssl curl sudo python-ctypes sysv-rc net-tools rsyslog cron vim dmidecode apt-transport-https && rm -rf /var/lib/apt/lists/*
 COPY setup.sh main.sh $tmpdir/
 WORKDIR ${tmpdir}
 RUN chmod 775 $tmpdir/*.sh; sync; $tmpdir/setup.sh

--- a/ci_feature/main.sh
+++ b/ci_feature/main.sh
@@ -86,6 +86,8 @@ dpkg -l | grep omi | awk '{print $2 " " $3}'
 dpkg -l | grep omsagent | awk '{print $2 " " $3}'
 dpkg -l | grep docker-cimprov | awk '{print $2 " " $3}' 
 
+#stopping rsyslog to disable collecting syslog for all debug messages
+service rsyslog stop
 
 shutdown() {
 	/opt/omi/bin/service_control stop


### PR DESCRIPTION
Unmount volume /var/log from host so that that rsyslogd can access the folder /var/log
Stop rsyslogd after installation so that no syslogs are written until explicilty enabled - this is limit the number of messages we write so that the disk space doesnt get full quickly