### PR TITLE
Changes to get the new oms host agent and dockerfile changes for telemetry

### DIFF
--- a/Kubernetes/omsagent.yaml
+++ b/Kubernetes/omsagent.yaml
@@ -281,7 +281,7 @@ spec:
    serviceAccountName: omsagent
    containers:
      - name: omsagent 
-       image: "microsoft/oms:ciprod03122019"
+       image: "microsoft/oms:ciprod04232019"
        imagePullPolicy: IfNotPresent
        resources:
         limits:
@@ -390,7 +390,7 @@ spec:
    serviceAccountName: omsagent
    containers:
      - name: omsagent 
-       image: "microsoft/oms:ciprod03122019"
+       image: "microsoft/oms:ciprod04232019"
        imagePullPolicy: IfNotPresent
        resources:
         limits:

--- a/ci_feature/Dockerfile
+++ b/ci_feature/Dockerfile
@@ -5,7 +5,7 @@ com.microsoft.product="OMS  Container Docker Provider" \
 com.microsoft.version="2.0.0-7"
 ENV tmpdir /opt
 ENV APPLICATIONINSIGHTS_AUTH OTQzNWI0M2YtOTdkNS00ZGVkLThkOTAtYjA0Nzk1OGU2ZTg3
-ENV AGENT_VERSION 20190418-1
+ENV AGENT_VERSION 20190423
 ENV HOST_MOUNT_PREFIX /hostfs
 ENV HOST_PROC /hostfs/proc
 ENV HOST_SYS /hostfs/sys

--- a/ci_feature/Dockerfile
+++ b/ci_feature/Dockerfile
@@ -5,7 +5,7 @@ com.microsoft.product="OMS  Container Docker Provider" \
 com.microsoft.version="2.0.0-7"
 ENV tmpdir /opt
 ENV APPLICATIONINSIGHTS_AUTH OTQzNWI0M2YtOTdkNS00ZGVkLThkOTAtYjA0Nzk1OGU2ZTg3
-ENV AGENT_VERSION 20190423
+ENV AGENT_VERSION ciprod04232019
 ENV HOST_MOUNT_PREFIX /hostfs
 ENV HOST_PROC /hostfs/proc
 ENV HOST_SYS /hostfs/sys

--- a/ci_feature/setup.sh
+++ b/ci_feature/setup.sh
@@ -9,7 +9,7 @@ sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-wget https://dockerprovider.blob.core.windows.net/omsagent/omsagent-1.10.0-1.universal.x64.sh
+wget https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_v1.10.0-1/omsagent-1.10.0-1.universal.x64.sh
 
 #create file to disable omi service startup script
 touch /etc/.omi_disable_service_control

--- a/ci_feature_prod/Dockerfile
+++ b/ci_feature_prod/Dockerfile
@@ -5,7 +5,7 @@ com.microsoft.product="OMS Container Docker Provider" \
 com.microsoft.version="2.0.0-3"
 ENV tmpdir /opt
 ENV APPLICATIONINSIGHTS_AUTH NzAwZGM5OGYtYTdhZC00NThkLWI5NWMtMjA3ZjM3NmM3YmRi
-ENV AGENT_VERSION ciprod04182019
+ENV AGENT_VERSION ciprod04232019
 ENV HOST_MOUNT_PREFIX /hostfs
 ENV HOST_PROC /hostfs/proc
 ENV HOST_SYS /hostfs/sys

--- a/ci_feature_prod/setup.sh
+++ b/ci_feature_prod/setup.sh
@@ -9,7 +9,7 @@ sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-wget https://dockerprovider.blob.core.windows.net/omsagent/omsagent-1.10.0-1.universal.x64.sh
+wget https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_v1.10.0-1/omsagent-1.10.0-1.universal.x64.sh
 
 #create file to disable omi service startup script
 touch /etc/.omi_disable_service_control


### PR DESCRIPTION
1. Update https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_v1.10.0-1/omsagent-1.10.0-1.universal.x64.sh location for host agent in ci_feature and ci_feature_prod.
2. Update dockerfile to the get the right version of the agent for telemetry